### PR TITLE
Add custom rule for amplify deployments

### DIFF
--- a/careconnect2025/terraform_aws/general/modules/amplify/amplify.tf
+++ b/careconnect2025/terraform_aws/general/modules/amplify/amplify.tf
@@ -6,6 +6,13 @@ resource "aws_amplify_app" "amplify" {
   # repository          = var.github_repo
   iam_service_role_arn = var.cc_app_role_arn
 
+  # Add rewrite rule - ensure that any request to a URL not containing a dot will be rewritten to /index.html
+  custom_rule {
+    source = "</^((?!\\.).)*$/>"
+    target = "/index.html"
+    status = "200"
+  }
+
   environment_variables = {
     ENV = "dev"
   }


### PR DESCRIPTION
Add custom rule - ensure that any request to a URL not containing a dot will be rewritten to /index.html