### PR TITLE
389-cc Adding lambda
* Updating IAM Roles

### DIFF
--- a/careconnect2025/terraform_aws/compute/main.tf
+++ b/careconnect2025/terraform_aws/compute/main.tf
@@ -60,11 +60,11 @@ resource "aws_lambda_function" "cc_main_backend_lambda" {
         APP_FRONTEND_BASE_URL = "https://${data.terraform_remote_state.cc_common_state.outputs.amplify_url}"
         BASE_URL              = "${data.terraform_remote_state.cc_common_state.outputs.main_api_endpoint}"
         CORS_ALLOWED_LIST     = "${var.cors_allowed_list},https://${data.terraform_remote_state.cc_common_state.outputs.amplify_url}"
-        CC_DB_USER_SSM_PARAM  = "${data.terraform_remote_state.cc_common_state.outputs.rds_user_param_arn}"
-        CC_DB_PASS_SSM_PARAM  = "${data.terraform_remote_state.cc_common_state.outputs.rds_pass_param_arn}"
+        CC_DB_USER_SSM_PARAM  = "${data.terraform_remote_state.cc_common_state.outputs.rds_user_param_name}"
+        CC_DB_PASS_SSM_PARAM  = "${data.terraform_remote_state.cc_common_state.outputs.rds_pass_param_name}"
         JDBC_URI              = "jdbc:mysql://${data.terraform_remote_state.cc_common_state.outputs.db_endpoint}/${data.terraform_remote_state.cc_common_state.outputs.db_name}"
-        DB_USER               = "${data.terraform_remote_state.cc_common_state.outputs.rds_user_param_arn}"
-        DB_PASSWORD           = "${data.terraform_remote_state.cc_common_state.outputs.rds_pass_param_arn}"
+        DB_USER               = "${data.terraform_remote_state.cc_common_state.outputs.rds_user_param_name}"
+        DB_PASSWORD           = "${data.terraform_remote_state.cc_common_state.outputs.rds_pass_param_name}"
       }
     )
   }

--- a/careconnect2025/terraform_aws/compute/main.tf
+++ b/careconnect2025/terraform_aws/compute/main.tf
@@ -1,0 +1,79 @@
+terraform {
+
+  # Consider using workspaces for different environments backends like dev, staging, prod
+  # That could help in naming the resources differently based on the environment
+  backend "s3" {
+    bucket       = "cc-iac-us-east-1-641592448579"
+    key          = "tf-state/careconnect-compute.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.90.0"
+    }
+  }
+}
+
+data "terraform_remote_state" "cc_common_state" {
+  backend = "s3"
+  config = {
+    bucket = "${var.iac_cc_s3_bucket_name}"
+    key    = "tf-state/careconnect.tfstate"
+    region = "us-east-1"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "cc_main_lambda_log_group" {
+  name              = "/aws/lambda/cc_main_backend"
+  retention_in_days = 90
+
+  tags = merge(var.default_tags, {
+    Name = "cc_lambda_main_backend_log_group"
+  })
+}
+
+resource "aws_lambda_function" "cc_main_backend_lambda" {
+  function_name = "cc_main_backend"
+  description   = "Main backend Lambda function(Compute) for CareConnect"
+  handler       = "com.careconnect.CcLambdaHandler::handleRequest"
+  runtime       = "java17"
+  role          = data.terraform_remote_state.cc_common_state.outputs.cc_app_role_arn
+  memory_size   = 2048
+  timeout       = 120
+#   filename      = "NONAMEYET"
+  s3_bucket     = var.iac_cc_s3_bucket_name
+  s3_key        = var.cc_main_backend_package_zip_s3key
+  publish       = true
+  vpc_config {
+    security_group_ids = [data.terraform_remote_state.cc_common_state.outputs.cc_compute_sg_id]
+    subnet_ids         = data.terraform_remote_state.cc_common_state.outputs.cc_sbn_ids
+  }
+  environment {
+    variables = merge(
+      var.cc_main_compute_env_vars,
+      {
+        CC_APP_ROLE           = "${data.terraform_remote_state.cc_common_state.outputs.cc_app_role_arn}"
+        APP_FRONTEND_BASE_URL = "https://${data.terraform_remote_state.cc_common_state.outputs.amplify_url}"
+        BASE_URL              = "${data.terraform_remote_state.cc_common_state.outputs.main_api_endpoint}"
+        CORS_ALLOWED_LIST     = "${var.cors_allowed_list},https://${data.terraform_remote_state.cc_common_state.outputs.amplify_url}"
+        CC_DB_USER_SSM_PARAM  = "${data.terraform_remote_state.cc_common_state.outputs.rds_user_param_arn}"
+        CC_DB_PASS_SSM_PARAM  = "${data.terraform_remote_state.cc_common_state.outputs.rds_pass_param_arn}"
+        JDBC_URI              = "jdbc:mysql://${data.terraform_remote_state.cc_common_state.outputs.db_endpoint}/${data.terraform_remote_state.cc_common_state.outputs.db_name}"
+        DB_USER               = "${data.terraform_remote_state.cc_common_state.outputs.rds_user_param_arn}"
+        DB_PASSWORD           = "${data.terraform_remote_state.cc_common_state.outputs.rds_pass_param_arn}"
+      }
+    )
+  }
+  logging_config {
+    log_group  = aws_cloudwatch_log_group.cc_main_lambda_log_group.name
+    log_format = "Text"
+  }
+  snap_start {
+    apply_on = "PublishedVersions"
+  }
+  tags = merge(var.default_tags, { Name = "cc_main_backend" })
+}

--- a/careconnect2025/terraform_aws/compute/outputs.tf
+++ b/careconnect2025/terraform_aws/compute/outputs.tf
@@ -1,0 +1,4 @@
+output "cc_main_backend_lambda" {
+  description = "Attributes of the main backend Lambda function"
+  value       = aws_lambda_function.cc_main_backend_lambda
+}

--- a/careconnect2025/terraform_aws/compute/variables.tf
+++ b/careconnect2025/terraform_aws/compute/variables.tf
@@ -1,0 +1,27 @@
+variable "default_tags" {
+  description = "Default tags to apply to all resources"
+  type        = map(string)
+  default = {
+    Purpose    = "capstone at UMGC"
+    CourseCode = "SWEN-670"
+    Project    = "careconnect"
+    Use        = "IaC"
+  }
+}
+variable "iac_cc_s3_bucket_name" {
+  description = "S3 bucket name where application packages are stored"
+  type        = string
+}
+variable "cc_main_backend_package_zip_s3key" {
+  description = "Full S3 key for the main backend package zip file"
+  type        = string
+}
+variable "cc_main_compute_env_vars" {
+  description = "Environment variables for the main Lambda function"
+  type        = map(string)
+}
+variable "cors_allowed_list" {
+  description = "List of allowed CORS origins"
+  type        = string
+  default     = "http://localhost:*,http://127.0.0.1:*"
+}

--- a/careconnect2025/terraform_aws/general/main.tf
+++ b/careconnect2025/terraform_aws/general/main.tf
@@ -51,7 +51,6 @@ module "iam" {
   default_tags               = var.default_tags
   primary_region             = var.primary_region
   cc_internal_bucket_arn     = module.s3_internal.internal_s3_bucket.arn
-  cc_main_backend_lambda_arn = "arn:aws:lambda:${var.primary_region}:${data.aws_caller_identity.current.account_id}:function:${var.cc_main_lambda_name}"
   only_compute_required_ssm_parameters = [
     module.ssm.rds_username_param.arn,
     module.ssm.rds_password_param.arn

--- a/careconnect2025/terraform_aws/general/main.tf
+++ b/careconnect2025/terraform_aws/general/main.tf
@@ -22,10 +22,7 @@ provider "aws" {
   region = var.primary_region
 }
 
-provider "aws" {
-  alias  = "secondary"
-  region = var.secondary_region
-}
+data "aws_caller_identity" "current" {}
 
 module "vpc" {
   source         = "./modules/vpc"
@@ -50,12 +47,15 @@ module "ssm" {
   rds_pass_param_name = var.rds_pass_param_name
 }
 module "iam" {
-  source                  = "./modules/iam"
-  default_tags            = var.default_tags
-  primary_region          = var.primary_region
-  cc_internal_bucket_arn  = module.s3_internal.internal_s3_bucket.arn
-  main_rds_user_param_arn = module.ssm.rds_username_param.arn
-  main_rds_pass_param_arn = module.ssm.rds_password_param.arn
+  source                     = "./modules/iam"
+  default_tags               = var.default_tags
+  primary_region             = var.primary_region
+  cc_internal_bucket_arn     = module.s3_internal.internal_s3_bucket.arn
+  cc_main_backend_lambda_arn = "arn:aws:lambda:${var.primary_region}:${data.aws_caller_identity.current.account_id}:function:${var.cc_main_lambda_name}"
+  only_compute_required_ssm_parameters = [
+    module.ssm.rds_username_param.arn,
+    module.ssm.rds_password_param.arn
+  ]
 }
 
 module "cloudmap" {
@@ -83,7 +83,7 @@ module "ecs" {
   source                    = "./modules/ecs"
   cc_ecr_repo_url           = module.ecr.core_repository_url
   subnet_ids                = module.vpc.cc_subnet_ids
-  cc_ecs_sg_id              = module.vpc.cc_ecs_sg_id
+  cc_ecs_sg_id              = module.vpc.cc_compute_sg_id
   vpc_id                    = module.vpc.vpc_id
   cc_ecs_exe_role_arn       = module.iam.cc_ecs_exe_role_arn
   cc_app_role_arn           = module.iam.cc_app_role_arn
@@ -110,17 +110,12 @@ module "sfn_sm" {
 }
 
 module "amplify" {
-  source  = "./modules/amplify"
+  source          = "./modules/amplify"
   default_tags    = var.default_tags
-  primary_region = var.primary_region
+  primary_region  = var.primary_region
   cc_app_role_arn = module.iam.cc_app_role_arn
 }
 
-
-# module "cognito" {
-#   source       = "./modules/cognito"
-#   default_tags = var.default_tags
-# }
 
 module "main_api" {
   source                 = "./modules/api"
@@ -130,6 +125,5 @@ module "main_api" {
   cc_main_api_sg_id      = module.vpc.cc_main_api_sg_id
   cc_main_sbn_ids        = module.vpc.cc_subnet_ids
   default_tags           = var.default_tags
-  # cc_cognito_user_pool_arn = module.cognito.cc_cognito_user_pool
 }
 

--- a/careconnect2025/terraform_aws/general/modules/amplify/amplify.tf
+++ b/careconnect2025/terraform_aws/general/modules/amplify/amplify.tf
@@ -1,7 +1,7 @@
 # Amplify app
 resource "aws_amplify_app" "amplify" {
-  name                = "careconnect"
-  platform            = "WEB"
+  name     = "careconnect"
+  platform = "WEB"
   # Disable for now to test deploying Amplify without GitHub account
   # repository          = var.github_repo
   iam_service_role_arn = var.cc_app_role_arn

--- a/careconnect2025/terraform_aws/general/modules/amplify/outputs.tf
+++ b/careconnect2025/terraform_aws/general/modules/amplify/outputs.tf
@@ -1,7 +1,6 @@
 output "amplify_app_id" {
   value = aws_amplify_app.amplify.id
 }
-
 output "amplify_branch_url" {
-  value = aws_amplify_branch.care_connect_develop.id
+  value = "${aws_amplify_branch.care_connect_develop.branch_name}.${aws_amplify_app.amplify.default_domain}"
 }

--- a/careconnect2025/terraform_aws/general/modules/amplify/variables.tf
+++ b/careconnect2025/terraform_aws/general/modules/amplify/variables.tf
@@ -7,7 +7,7 @@ variable "primary_region" {
 variable "github_repo" {
   description = "GitHub repo HTTPS URL (e.g., https://github.com/umgc/summer2025)"
   type        = string
-  default = "https://github.com/umgc/summer2025"
+  default     = "https://github.com/umgc/summer2025"
 }
 variable "github_branch" {
   description = "The branch name to connect to Amplify"

--- a/careconnect2025/terraform_aws/general/modules/db/outputs.tf
+++ b/careconnect2025/terraform_aws/general/modules/db/outputs.tf
@@ -1,3 +1,9 @@
 output "cc_db_endpoint" {
   value = aws_db_instance.cc_db.endpoint
 }
+output "cc_db_port" {
+  value = aws_db_instance.cc_db.port
+}
+output "cc_db_name" {
+  value = aws_db_instance.cc_db.db_name
+}

--- a/careconnect2025/terraform_aws/general/modules/iam/cc_app_role.tf
+++ b/careconnect2025/terraform_aws/general/modules/iam/cc_app_role.tf
@@ -56,9 +56,13 @@ resource "aws_iam_role" "cc_app_role" {
     Statement = [{
       Effect = "Allow"
       Principal = {
-        Service = ["ecs-tasks.amazonaws.com",
+        Service = [
+          "ecs-tasks.amazonaws.com",
           "events.amazonaws.com",
-        "states.amazonaws.com"]
+          "states.amazonaws.com",
+          "lambda.amazonaws.com",
+          "apigateway.amazonaws.com",
+        ]
       }
       Action = "sts:AssumeRole"
     }]
@@ -87,6 +91,17 @@ resource "aws_iam_policy" "cc_app_role_policy" {
         ]
       },
       {
+        Sid    = "AccessECR",
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = "*"
+      },
+      {
         Sid    = "AccessRDS",
         Effect = "Allow"
         Action = [
@@ -103,8 +118,7 @@ resource "aws_iam_policy" "cc_app_role_policy" {
           "ssm:GetParam*",
           "ssm:PutParameter",
         ]
-        Resource = ["${var.main_rds_user_param_arn}",
-        "${var.main_rds_pass_param_arn}"]
+        Resource = var.only_compute_required_ssm_parameters
       },
       {
         Sid    = "AccessCloudWatchLogs",
@@ -145,6 +159,27 @@ resource "aws_iam_policy" "cc_app_role_policy" {
           "${aws_iam_role.cc_app_role.arn}",
           "${aws_iam_role.ecs_exe_task_execution.arn}"
         ]
+      },
+      {
+        Sid    = "LambdaGeneralAccess"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs",
+          "xray:GetTrace*",
+          "xray:BatchGetTraces",
+          "iam:GetPolicy",
+          "iam:ListPolicies",
+          "iam:GetPolicyVersion",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListRoles",
+          "iam:GetRole"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/careconnect2025/terraform_aws/general/modules/iam/variable.tf
+++ b/careconnect2025/terraform_aws/general/modules/iam/variable.tf
@@ -8,10 +8,6 @@ variable "cc_internal_bucket_arn" {
   description = "ARN of the internal S3 bucket for CareConnect"
   type        = string
 }
-variable "cc_main_backend_lambda_arn" {
-  description = "ARN of the main backend Lambda function"
-  type        = string
-}
 variable "only_compute_required_ssm_parameters" {
   description = "List of SSM parameters required for the main Lambda function"
   type        = list(string)

--- a/careconnect2025/terraform_aws/general/modules/iam/variable.tf
+++ b/careconnect2025/terraform_aws/general/modules/iam/variable.tf
@@ -8,11 +8,11 @@ variable "cc_internal_bucket_arn" {
   description = "ARN of the internal S3 bucket for CareConnect"
   type        = string
 }
-variable "main_rds_user_param_arn" {
-  description = "ARN of the main RDS user parameter store"
+variable "cc_main_backend_lambda_arn" {
+  description = "ARN of the main backend Lambda function"
   type        = string
 }
-variable "main_rds_pass_param_arn" {
-  description = "ARN of the main RDS password parameter store"
-  type        = string
+variable "only_compute_required_ssm_parameters" {
+  description = "List of SSM parameters required for the main Lambda function"
+  type        = list(string)
 }

--- a/careconnect2025/terraform_aws/general/modules/vpc/outputs.tf
+++ b/careconnect2025/terraform_aws/general/modules/vpc/outputs.tf
@@ -10,12 +10,9 @@ output "cc_db_main_sbn_group" {
 output "cc_subnet_ids" {
   value = [aws_subnet.private_subneta.id, aws_subnet.private_subnetb.id]
 }
-output "cc_ecs_sg_id" {
-  value = aws_security_group.cc_ecs_sg.id
+output "cc_compute_sg_id" {
+  value = aws_security_group.cc_compute_sg.id
 }
-# output "cc_ecs_lb_sg_id" {
-#   value = aws_security_group.cc_ecs_lb_sg.id
-# }
 output "cc_main_api_sg_id" {
   value = aws_security_group.cc_api_sg.id
 }

--- a/careconnect2025/terraform_aws/general/modules/vpc/vpc.tf
+++ b/careconnect2025/terraform_aws/general/modules/vpc/vpc.tf
@@ -45,7 +45,7 @@ resource "aws_security_group" "cc_api_sg" {
   tags = merge(var.default_tags, { Name : "cc-apigw-sg" })
 }
 
-resource "aws_security_group" "cc_ecs_sg" {
+resource "aws_security_group" "cc_compute_sg" {
   vpc_id = aws_vpc.vpc.id
   name   = "cc-ecs-sg"
 
@@ -73,7 +73,7 @@ resource "aws_security_group" "cc_rds_sg" {
     from_port       = 3306
     to_port         = 3306
     protocol        = "tcp"
-    security_groups = [aws_security_group.cc_ecs_sg.id]
+    security_groups = [aws_security_group.cc_compute_sg.id]
   }
 
   egress {

--- a/careconnect2025/terraform_aws/general/outputs.tf
+++ b/careconnect2025/terraform_aws/general/outputs.tf
@@ -23,9 +23,9 @@ output "cc_sbn_ids" {
 output "amplify_url" {
   value = replace(module.amplify.amplify_branch_url, "/", ".")
 }
-output "rds_pass_param_arn" {
-  value = module.ssm.rds_password_param.arn
+output "rds_pass_param_name" {
+  value = module.ssm.rds_password_param.name
 }
-output "rds_user_param_arn" {
-  value = module.ssm.rds_username_param.arn
+output "rds_user_param_name" {
+  value = module.ssm.rds_username_param.name
 }

--- a/careconnect2025/terraform_aws/general/outputs.tf
+++ b/careconnect2025/terraform_aws/general/outputs.tf
@@ -1,20 +1,31 @@
 
-# output "alb_dns_name" {
-#   value = aws_lb.main.dns_name
-# }
-
-# output "ecs_cluster_name" {
-#   value = aws_ecs_cluster.main.name
-# }
-
-# output "ecs_service_name" {
-#   value = aws_ecs_service.main.name
-# }
-
-# output "rds_endpoint" {
-#   value = aws_db_instance.postgres.endpoint
-# }
-
-# output "api_gateway_url" {
-#   value = aws_apigatewayv2_stage.main.invoke_url
-# }
+output "main_api_endpoint" {
+  value = module.main_api.cc_man_api_endpoint
+}
+output "db_endpoint" {
+  value = module.rds.cc_db_endpoint
+}
+output "db_port" {
+  value = module.rds.cc_db_port
+}
+output "db_name" {
+  value = module.rds.cc_db_name
+}
+output "cc_app_role_arn" {
+  value = module.iam.cc_app_role_arn
+}
+output "cc_compute_sg_id" {
+  value = module.vpc.cc_compute_sg_id
+}
+output "cc_sbn_ids" {
+  value = module.vpc.cc_subnet_ids
+}
+output "amplify_url" {
+  value = replace(module.amplify.amplify_branch_url, "/", ".")
+}
+output "rds_pass_param_arn" {
+  value = module.ssm.rds_password_param.arn
+}
+output "rds_user_param_arn" {
+  value = module.ssm.rds_username_param.arn
+}

--- a/careconnect2025/terraform_aws/general/variables.tf
+++ b/careconnect2025/terraform_aws/general/variables.tf
@@ -37,25 +37,3 @@ variable "rds_password" {
   type        = string
   sensitive   = true
 }
-variable "iac_cc_s3_bucket_name" {
-  description = "S3 bucket name where application packages are stored"
-  type        = string
-}
-variable "cc_main_backend_package_zip_s3key" {
-  description = "Full S3 key for the main backend package zip file"
-  type        = string
-}
-variable "cc_main_compute_env_vars" {
-  type    = map(string)
-  default = {}
-}
-variable "cors_allowed_list" {
-  description = "List of allowed CORS origins"
-  type        = string
-  default     = "http://localhost:8080,http://localhost:*,http://127.0.0.1:*"
-}
-variable "cc_main_lambda_name" {
-  description = "Name of the main backend Lambda function"
-  type        = string
-  default     = "cc_main_lambda_name"
-}

--- a/careconnect2025/terraform_aws/general/variables.tf
+++ b/careconnect2025/terraform_aws/general/variables.tf
@@ -3,11 +3,6 @@ variable "primary_region" {
   default     = "us-east-1"
 }
 
-variable "secondary_region" {
-  description = "The secondary AWS region"
-  default     = "us-west-2"
-}
-
 variable "core_task_env_vars" {
   type    = list(map(string))
   default = []
@@ -41,4 +36,26 @@ variable "rds_password" {
   description = "RDS database password"
   type        = string
   sensitive   = true
+}
+variable "iac_cc_s3_bucket_name" {
+  description = "S3 bucket name where application packages are stored"
+  type        = string
+}
+variable "cc_main_backend_package_zip_s3key" {
+  description = "Full S3 key for the main backend package zip file"
+  type        = string
+}
+variable "cc_main_compute_env_vars" {
+  type    = map(string)
+  default = {}
+}
+variable "cors_allowed_list" {
+  description = "List of allowed CORS origins"
+  type        = string
+  default     = "http://localhost:8080,http://localhost:*,http://127.0.0.1:*"
+}
+variable "cc_main_lambda_name" {
+  description = "Name of the main backend Lambda function"
+  type        = string
+  default     = "cc_main_lambda_name"
 }


### PR DESCRIPTION
This is providing a new terraform app an necessary changes to the general terraform app that allow the creation of a new compute (a lambda) for Care Connect.
We use `terraform_remote_state` to use properties from the general app as it will be created first. 