### PR TITLE
cc- Centralizing AWS Access And Clients

### DIFF
--- a/careconnect2025/backend/core/README.md
+++ b/careconnect2025/backend/core/README.md
@@ -33,15 +33,22 @@ Although, the following would be similar to most platforms an IDEs you want to u
 
         3. Add your variables in the `Environment Variables` field, like so. The values in the example should match what you can use.
         ```
-        ADMIN_EMAIL=bomplar@gmail.com;ADMIN_EMAIL_PASSWORD=<SENSITIVE>;DB_PASSWORD=<ADD YOUR USER DB PASSWORD HERE>;DB_USER=root;JDBC_URI=jdbc:mysql://localhost:3306/careconnect;MAIL_HOSTNAME=smtp.gmail.com;MAIL_PORT=587
+        DB_PASSWORD=<ADD YOUR USER DB PASSWORD HERE>;DB_USER=root;JDBC_URI=jdbc:mysql://localhost:3306/careconnect;MAIL_HOSTNAME=smtp.gmail.com;MAIL_PORT=587
         ```
         
         The format is simple `KEY=value;NEW_KEY=value` <br/>You can also use a file if you prefer or add the variable with the GUI. 
         
         - Click on the last button of the `Envirionment Variables` field. You should see a screen like below, fill it out like by line.
                 ![Add Environment Variables with GUI](_readme/Add_Variable_w_GUI.png)
+3. Add AWS Secret and Region (Configure AWS CLI)
 
+    There are multiples way you can do that.<br/>
+    You need to have `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` setup in your environment variables. You do that in the IDE or make it global in your System Environment variable.
+    Go to for more details [Configure your AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) - to make it simple we suggest you to use environment variables [here is the sub link](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 
+4. Retrieving properties from SSM Parameter Store
+    Add the full name of your properties in your environment variable file.<br/>
+You can add value of the prop from your local because if the `ParameterStoreService` cannot retrieve the parameter it would return a `null` with could be a fallback for your configuration, if you set it up accordingly.
 
 ## Run the Spring Boot Backend App
 On your terminal

--- a/careconnect2025/backend/core/pom.xml
+++ b/careconnect2025/backend/core/pom.xml
@@ -129,6 +129,10 @@
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>ssm</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>s3</artifactId>
 		</dependency>
 		<dependency>

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/config/AwsAccessConfig.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/config/AwsAccessConfig.java
@@ -1,0 +1,42 @@
+package com.careconnect.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+@Configuration
+public class AwsAccessConfig {
+
+
+    @Bean
+    public Region defaultAwsRegion() {
+        return new DefaultAwsRegionProviderChain().getRegion();
+    }
+
+
+    @Bean
+    public DefaultCredentialsProvider awsCredentialsProvider() {
+        return DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(defaultAwsRegion())
+                .credentialsProvider(awsCredentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public SsmClient ssmClient(DefaultCredentialsProvider credentialsProvider) {
+        return SsmClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(defaultAwsRegion())
+                .build();
+    }
+}

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/config/DatabaseConfig.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/config/DatabaseConfig.java
@@ -30,7 +30,6 @@ public class DatabaseConfig {
 
     /**
      * Will get the sensitive value/properties for database connection from SSM Parameter Store
-     * With the {@link ConditionalOnBean} if that can be created, Spring will try to auto-configure
      * @return DataSourceProperties
      */
     @Bean

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/config/DatabaseConfig.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/config/DatabaseConfig.java
@@ -1,0 +1,51 @@
+package com.careconnect.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.*;
+
+import com.careconnect.service.ParameterStoreService;
+import software.amazon.awssdk.services.ssm.SsmClient;
+
+@Configuration
+public class DatabaseConfig {
+
+    @Value("${spring.datasource.url}")
+    private String jdbcUrl;
+
+    @Value("${spring.datasource.username}")
+    private String userParameter;
+
+    @Value("${spring.datasource.password}")
+    private String passwordParameter;
+
+    private final ParameterStoreService parameterService;
+
+    @Autowired(required = false)
+    public DatabaseConfig(ParameterStoreService parameterService) {
+        this.parameterService = parameterService;
+    }
+
+    /**
+     * Will get the sensitive value/properties for database connection from SSM Parameter Store
+     * With the {@link ConditionalOnBean} if that can be created, Spring will try to auto-configure
+     * @return DataSourceProperties
+     */
+    @Bean
+    @DependsOn("ssmClient")
+    @Primary
+    public DataSourceProperties dataSourceProperties() {
+        DataSourceProperties properties = new DataSourceProperties();
+        String url = parameterService.getSecureParameter(jdbcUrl);
+        String username = parameterService.getSecureParameter(userParameter);
+        String password = parameterService.getSecureParameter(passwordParameter);
+
+        properties.setUrl(url);
+        properties.setUsername(username);
+        properties.setPassword(password);
+
+        return properties;
+    }
+}

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/config/S3Config.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/config/S3Config.java
@@ -10,17 +10,23 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import com.careconnect.dto.S3Props;
 
+/***
+ * @deprecated
+ * "Use and define new AWS service Clients In the AwsAccessConfig class."
+ * Will be deleted soon
+ */
+@Deprecated
 @Configuration
 public class S3Config {
 
     @Autowired
     private S3Props s3Props;
 
-    @Bean
+    /*@Bean
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(s3Props.getRegion()))
                 .credentialsProvider(DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build())
                 .build();
-    }
+    }*/
 }

--- a/careconnect2025/backend/core/src/main/java/com/careconnect/service/ParameterStoreService.java
+++ b/careconnect2025/backend/core/src/main/java/com/careconnect/service/ParameterStoreService.java
@@ -1,0 +1,52 @@
+package com.careconnect.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.SsmException;
+
+@Service
+public class ParameterStoreService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ParameterStoreService.class);
+    private final SsmClient ssmClient;
+
+    @Autowired(required = false)
+    public ParameterStoreService(SsmClient ssmClient) {
+        this.ssmClient = ssmClient;
+    }
+
+    /**
+     * Retrieves a parameter from SSM Parameter Store
+     *
+     * @param parameterName The name of the parameter to retrieve
+     * @param withDecryption Whether to decrypt the parameter (for SecureString type)
+     * @return The parameter value or null if not found
+     */
+    public String getParameter(String parameterName, boolean withDecryption) {
+        try {
+            GetParameterRequest request = GetParameterRequest.builder()
+                    .name(parameterName)
+                    .withDecryption(withDecryption)
+                    .build();
+
+            GetParameterResponse response = ssmClient.getParameter(request);
+            return response.parameter().value();
+        } catch (SsmException e) {
+            logger.error("Error retrieving parameter {}: {}", parameterName, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Convenience method for retrieving a parameter with decryption
+     */
+    public String getSecureParameter(String parameterName) {
+        return getParameter(parameterName, true);
+    }
+}
+

--- a/careconnect2025/terraform_aws/README.md
+++ b/careconnect2025/terraform_aws/README.md
@@ -19,7 +19,7 @@ _Unless you already have your own s3 bucket ready for the state.<br/>In that cas
 ## Pre-requisites
 1. You need an AWS user account with the **Access Credentials** for it.
 1. Install AWS CLI. Follow this [Install or Update AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-1. [Configure your AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) - to make it simple we suggestion you to use environment variables [here is the sub link](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
+1. [Configure your AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) - to make it simple we suggest you to use environment variables [here is the sub link](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 1. Install & Configure Terraform [Link](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 
 


### PR DESCRIPTION
This change is...:
* Centralizing AWS Access And Clients
* Adding ParameterStoreService
* Using ParameterStoreService to set DB Properties. That pattern will be used to retrieve most sensitive properties needed to configure the services. 
* Commenting out Old S3Client. S3Config will go away soon.



YOU HAVE TO HAVE AWS SECRETS CONFIGURE TO HAVE THIS WORKING.